### PR TITLE
Make the release suffix optional

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -127,7 +127,7 @@ NOTE: This command relies on `xmllint` being installed
 TIP: For details of how you can use `<revision>` in your builds see https://maven.apache.org/maven-ci-friendly.html[Maven CI Friendly Versions]
 
 ==== set_revision_to_pom
-Sets the `<version>` property to a `pom.xml` in the current directoy.
+Sets the `<version>` property to a `pom.xml` in the current directory.
 
 For example, given the following `pom.xml`:
 
@@ -211,11 +211,18 @@ version=$( strip_snapshot_suffix "1.2.3.BUILD-SNAPSHOT" )
 ==== get_next_release
 Get the release version based on a given snapshot version.
 
-The following call will set `next` to `1.0.0.RELEASE`.
+The following call will set `next` to `1.0.0`.
 
 [source,bash]
 ----
 next=$( get_next_milestone_release "1.0.0.BUILD-SNAPSHOT" )
+----
+
+You can also configure a release suffix; the following call will set `next` to `1.0.0.RELEASE`.
+
+[source,bash]
+----
+next=$( get_next_milestone_release "1.0.0.BUILD-SNAPSHOT" "RELEASE" )
 ----
 
 TIP: Version numbers in the form `1.0.0-SNAPSHOT` and `1.0.0.BUILD-SNAPSHOT` are both supported

--- a/concourse-java.sh
+++ b/concourse-java.sh
@@ -78,7 +78,11 @@ get_next_release() {
 	local version
 	local result
 	version=$( strip_snapshot_suffix "$1" )
-	result="${version}${join}RELEASE"
+	if [[ -n $2 ]]; then
+	  result="${version}${join}${2}"
+	else
+	  result="${version}"
+	fi
 	echo $result
 }
 

--- a/test/get_next_release.bats
+++ b/test/get_next_release.bats
@@ -84,11 +84,18 @@ source "$PWD/concourse-java.sh"
 	assert_output "2.0.0.B3"
 }
 
+@test "get_next_release() should return next release version with release suffix" {
+	run get_next_release "1.5.0.BUILD-SNAPSHOT" "RELEASE"
+	assert_output "1.5.0.RELEASE"
+	run get_next_release "1.5.0-SNAPSHOT" "RELEASE"
+	assert_output "1.5.0-RELEASE"
+}
+
 @test "get_next_release() should return next release version" {
 	run get_next_release "1.5.0.BUILD-SNAPSHOT"
-	assert_output "1.5.0.RELEASE"
+	assert_output "1.5.0"
 	run get_next_release "1.5.0-SNAPSHOT"
-	assert_output "1.5.0-RELEASE"
+	assert_output "1.5.0"
 }
 
 @test "get_next_release() when has no version should fail" {


### PR DESCRIPTION
Prior to this commit, the `get_next_release` function would only
consider the "RELEASE" suffix when generating the version string for the
next release.

This commit flips this default and now selects a suffix-less version by
default: "1.2.3-SNAPSHOT" -> "1.2.3". It is now possible to use a
specific release suffix with an additional argument:

```
next=$( get_next_milestone_release "1.0.0.BUILD-SNAPSHOT" "RELEASE" )
echo $next
1.0.0.RELEASE
```